### PR TITLE
Feature/1264 Send multiple compliance (emissions based) parameters and return data

### DIFF
--- a/src/constants/compliance-fields.ts
+++ b/src/constants/compliance-fields.ts
@@ -107,4 +107,39 @@ export const complianceFields = {
     label: 'State',
     value: 'state',
   },
+
+  unitId: {
+    label: 'Unit ID',
+    value: 'unitId',
+  },
+
+  complianceApproach: {
+    label: 'Compliance Approach',
+    value: 'complianceApproach',
+  },
+
+  avgPlanId: {
+    label: 'Averaging Plan ID',
+    value: 'avgPlanId',
+  },
+
+  emissionsLimitDisplay: {
+    label: 'Emissions Limit (lb/mmBtu)',
+    value: 'emissionsLimitDisplay',
+  },
+
+  avgPlanActual: {
+    label: 'Averaging Plan Actual Rate (lb/mmBtu)',
+    value: 'avgPlanActual',
+  },
+
+  actualEmissionsRate: {
+    label: 'Actual Emissions Rate (lb/mmBtu)',
+    value: 'actualEmissionsRate',
+  },
+
+  inCompliance: {
+    label: 'In Compliance',
+    value: 'inCompliance',
+  },
 };

--- a/src/constants/field-mappings.ts
+++ b/src/constants/field-mappings.ts
@@ -104,6 +104,20 @@ const allowanceCompliance = [
   { ...complianceFields.state },
 ];
 
+const emissionsCompliance = [
+  { ...complianceFields.year },
+  { ...complianceFields.facilityName },
+  { ...complianceFields.facilityId },
+  { ...complianceFields.unitId },
+  { ...complianceFields.ownerOperator },
+  { ...complianceFields.state },
+  { ...complianceFields.complianceApproach },
+  { ...complianceFields.avgPlanId },
+  { ...complianceFields.emissionsLimitDisplay },
+  { ...complianceFields.actualEmissionsRate },
+  { ...complianceFields.avgPlanActual },
+  { ...complianceFields.inCompliance },
+];
 export const fieldMappings = {
   allowances: {
     holdings: holdings,
@@ -113,5 +127,6 @@ export const fieldMappings = {
   compliance: {
     allowance: allowanceCompliance,
     allowanceNbpOtc: allowanceComplianceNbpOtc,
+    emissions: emissionsCompliance,
   },
 };

--- a/src/dto/emissions-compliance.dto.ts
+++ b/src/dto/emissions-compliance.dto.ts
@@ -1,0 +1,14 @@
+export class EmissionsComplianceDTO {
+  year: number;
+  facilityName: string;
+  facilityId: number;
+  unitId: string;
+  ownerOperator: string;
+  state: string;
+  complianceApproach: string;
+  avgPlanId: number;
+  emissionsLimitDisplay: number;
+  actualEmissionsRate: number;
+  avgPlanActual: number;
+  inCompliance: string;
+}

--- a/src/dto/emissions-compliance.params.dto.ts
+++ b/src/dto/emissions-compliance.params.dto.ts
@@ -1,0 +1,10 @@
+import { Transform } from 'class-transformer';
+import { IsOptional } from 'class-validator';
+
+import { ComplianceParamsDTO } from './compliance.params.dto';
+
+export class EmissionsComplianceParamsDTO extends ComplianceParamsDTO {
+  @IsOptional()
+  @Transform((value: string) => value.split('|').map(item => item.trim()))
+  year?: number[];
+}

--- a/src/emissions-compliance/emissions-compliance.controller.spec.ts
+++ b/src/emissions-compliance/emissions-compliance.controller.spec.ts
@@ -7,18 +7,37 @@ import { EmissionsComplianceController } from './emissions-compliance.controller
 import { AllowanceComplianceService } from '../allowance-compliance/allowance-compliance.service';
 import { AccountComplianceDimRepository } from '../allowance-compliance/account-compliance-dim.repository';
 import { OwnerYearDimRepository } from '../allowance-compliance/owner-year-dim.repository';
+import { EmissionsComplianceService } from './emissions-compliance.service';
+import { EmissionsComplianceDTO } from '../dto/emissions-compliance.dto';
+import { EmissionsComplianceParamsDTO } from '../dto/emissions-compliance.params.dto';
+import { State } from '../enum/state.enum';
+import { EmissionsComplianceMap } from '../maps/emissions-compliance.map';
+import { UnitComplianceDimRepository } from './unit-compliance-dim.repository';
+
+const mockRequest = (url: string) => {
+  return {
+    url,
+    res: {
+      setHeader: jest.fn(),
+    },
+  };
+};
 
 describe('-- Emissions Compliance Controller --', () => {
   let emissionsComplianceController: EmissionsComplianceController;
   let allowanceComplianceService: AllowanceComplianceService;
+  let emissionsComplianceService: EmissionsComplianceService;
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
       controllers: [EmissionsComplianceController],
       providers: [
         AllowanceComplianceService,
+        EmissionsComplianceService,
         AllowanceComplianceMap,
+        EmissionsComplianceMap,
         AccountComplianceDimRepository,
+        UnitComplianceDimRepository,
         OwnerYearDimRepository,
         OwnerOperatorsMap,
       ],
@@ -26,10 +45,37 @@ describe('-- Emissions Compliance Controller --', () => {
 
     emissionsComplianceController = module.get(EmissionsComplianceController);
     allowanceComplianceService = module.get(AllowanceComplianceService);
+    emissionsComplianceService = module.get(EmissionsComplianceService);
   });
 
   afterEach(() => {
     jest.resetAllMocks();
+  });
+
+  describe('* getEmissionsCompliance', () => {
+    const req: any = mockRequest('');
+    req.res.setHeader.mockReturnValue();
+
+    it('should call the service and return emissions compliance data ', async () => {
+      const expectedResults: EmissionsComplianceDTO[] = [];
+      const paramsDTO: EmissionsComplianceParamsDTO = {
+        year: [2019],
+        page: undefined,
+        perPage: undefined,
+        orisCode: [0],
+        ownerOperator: [''],
+        state: [State.AK],
+      };
+      jest
+        .spyOn(emissionsComplianceService, 'getEmissionsCompliance')
+        .mockResolvedValue(expectedResults);
+      expect(
+        await emissionsComplianceController.getEmissionsCompliance(
+          paramsDTO,
+          req,
+        ),
+      ).toBe(expectedResults);
+    });
   });
 
   describe('* getAllOwnerOperators', () => {

--- a/src/emissions-compliance/emissions-compliance.controller.ts
+++ b/src/emissions-compliance/emissions-compliance.controller.ts
@@ -1,14 +1,23 @@
-import { Get, Controller, UseInterceptors } from '@nestjs/common';
-import { ApiTags, ApiOkResponse, ApiExtraModels } from '@nestjs/swagger';
+import { Request } from 'express';
+import { Get, Controller, UseInterceptors, Query, Req } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOkResponse,
+  ApiExtraModels,
+  getSchemaPath,
+} from '@nestjs/swagger';
 
 import { Json2CsvInterceptor } from '../interceptors/json2csv.interceptor';
-
 import {
+  ApiQueryComplianceMultiSelect,
   BadRequestResponse,
   NotFoundResponse,
 } from '../utils/swagger-decorator.const';
 import { AllowanceComplianceService } from '../allowance-compliance/allowance-compliance.service';
 import { OwnerOperatorsDTO } from '../dto/owner-operators.dto';
+import { EmissionsComplianceDTO } from '../dto/emissions-compliance.dto';
+import { EmissionsComplianceParamsDTO } from '../dto/emissions-compliance.params.dto';
+import { EmissionsComplianceService } from './emissions-compliance.service';
 
 @Controller()
 @ApiTags('Emissions Compliance')
@@ -16,7 +25,38 @@ import { OwnerOperatorsDTO } from '../dto/owner-operators.dto';
 export class EmissionsComplianceController {
   constructor(
     private readonly allowanceComplianceService: AllowanceComplianceService,
+    private readonly emissionsComplianceService: EmissionsComplianceService,
   ) {}
+
+  @Get()
+  @ApiOkResponse({
+    description: 'Retrieve Emissions Compliance Data per filter criteria',
+    content: {
+      'application/json': {
+        schema: {
+          $ref: getSchemaPath(EmissionsComplianceDTO),
+        },
+      },
+      'text/csv': {
+        schema: {
+          type: 'string',
+        },
+      },
+    },
+  })
+  @BadRequestResponse()
+  @NotFoundResponse()
+  @ApiQueryComplianceMultiSelect()
+  @ApiExtraModels(EmissionsComplianceDTO)
+  getEmissionsCompliance(
+    @Query() emissionsComplianceParamsDTO: EmissionsComplianceParamsDTO,
+    @Req() req: Request,
+  ): Promise<EmissionsComplianceDTO[]> {
+    return this.emissionsComplianceService.getEmissionsCompliance(
+      emissionsComplianceParamsDTO,
+      req,
+    );
+  }
 
   @Get('owner-operators')
   @ApiOkResponse({

--- a/src/emissions-compliance/emissions-compliance.module.ts
+++ b/src/emissions-compliance/emissions-compliance.module.ts
@@ -7,19 +7,25 @@ import { AllowanceComplianceService } from '../allowance-compliance/allowance-co
 import { AllowanceComplianceMap } from '../maps/allowance-compliance.map';
 import { AccountComplianceDimRepository } from '../allowance-compliance/account-compliance-dim.repository';
 import { OwnerYearDimRepository } from '../allowance-compliance/owner-year-dim.repository';
+import { UnitComplianceDimRepository } from './unit-compliance-dim.repository';
+import { EmissionsComplianceService } from './emissions-compliance.service';
+import { EmissionsComplianceMap } from '../maps/emissions-compliance.map';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([
       AccountComplianceDimRepository,
       OwnerYearDimRepository,
+      UnitComplianceDimRepository,
     ]),
   ],
   controllers: [EmissionsComplianceController],
   providers: [
     AllowanceComplianceService,
+    EmissionsComplianceService,
     AllowanceComplianceMap,
     OwnerOperatorsMap,
+    EmissionsComplianceMap,
   ],
 })
 export class EmissionsComplianceModule {}

--- a/src/emissions-compliance/emissions-compliance.service.spec.ts
+++ b/src/emissions-compliance/emissions-compliance.service.spec.ts
@@ -1,0 +1,92 @@
+import { Test } from '@nestjs/testing';
+
+import { State } from '../enum/state.enum';
+import { EmissionsComplianceService } from './emissions-compliance.service';
+import { UnitComplianceDimRepository } from './unit-compliance-dim.repository';
+import { EmissionsComplianceMap } from '../maps/emissions-compliance.map';
+import { EmissionsComplianceParamsDTO } from '../dto/emissions-compliance.params.dto';
+
+const mockUnitComplianceDimRepository = () => ({
+  getEmissionsCompliance: jest.fn(),
+});
+
+const mockEmissionsComplianceMap = () => ({
+  many: jest.fn(),
+});
+
+const mockRequest = () => {
+  return {
+    res: {
+      setHeader: jest.fn(),
+    },
+  };
+};
+
+describe('-- Emissions Compliance Service --', () => {
+  let emissionsComplianceService;
+  let unitComplianceDimRepository;
+  let emissionsComplianceMap;
+  let req: any;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        EmissionsComplianceService,
+        {
+          provide: UnitComplianceDimRepository,
+          useFactory: mockUnitComplianceDimRepository,
+        },
+        {
+          provide: EmissionsComplianceMap,
+          useFactory: mockEmissionsComplianceMap,
+        },
+      ],
+    }).compile();
+
+    emissionsComplianceService = module.get(EmissionsComplianceService);
+    unitComplianceDimRepository = module.get(UnitComplianceDimRepository);
+    emissionsComplianceMap = module.get(EmissionsComplianceMap);
+    req = mockRequest();
+    req.res.setHeader.mockReturnValue();
+  });
+
+  describe('getEmissionsCompliance', () => {
+    it('calls EmissionsComplianceDimRepository.getEmissionsCompliance() and gets all emissions based compliance data from the repository', async () => {
+      unitComplianceDimRepository.getEmissionsCompliance.mockResolvedValue(
+        'list of emissions based compliance data',
+      );
+      emissionsComplianceMap.many.mockReturnValue('mapped DTOs');
+
+      let filters: EmissionsComplianceParamsDTO = {
+        year: [2019, 2020],
+        page: undefined,
+        perPage: undefined,
+        orisCode: [0],
+        ownerOperator: [''],
+        state: [State.AK],
+      };
+
+      let result = await emissionsComplianceService.getEmissionsCompliance(
+        filters,
+        req,
+      );
+
+      let filtersOtc: EmissionsComplianceParamsDTO = {
+        year: [2019, 2020],
+        page: undefined,
+        perPage: undefined,
+        orisCode: [0],
+        ownerOperator: [''],
+        state: [State.AK],
+      };
+
+      result = await emissionsComplianceService.getEmissionsCompliance(
+        filtersOtc,
+        req,
+      );
+
+      expect(emissionsComplianceMap.many).toHaveBeenCalled();
+      expect(result).toEqual('mapped DTOs');
+    });
+  });
+});

--- a/src/emissions-compliance/emissions-compliance.service.ts
+++ b/src/emissions-compliance/emissions-compliance.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Request } from 'express';
+
+import { fieldMappings } from '../constants/field-mappings';
+import { UnitComplianceDimRepository } from './unit-compliance-dim.repository';
+import { EmissionsComplianceMap } from '../maps/emissions-compliance.map';
+import { EmissionsComplianceParamsDTO } from '../dto/emissions-compliance.params.dto';
+import { EmissionsComplianceDTO } from '../dto/emissions-compliance.dto';
+
+@Injectable()
+export class EmissionsComplianceService {
+  constructor(
+    @InjectRepository(UnitComplianceDimRepository)
+    private readonly unitComplianceDimRepository: UnitComplianceDimRepository,
+    private readonly emissionsComplianceMap: EmissionsComplianceMap,
+  ) {}
+
+  async getEmissionsCompliance(
+    emissionsComplianceParamsDTO: EmissionsComplianceParamsDTO,
+    req: Request,
+  ): Promise<EmissionsComplianceDTO[]> {
+    const query = await this.unitComplianceDimRepository.getEmissionsCompliance(
+      emissionsComplianceParamsDTO,
+      req,
+    );
+
+    req.res.setHeader(
+      'X-Field-Mappings',
+      JSON.stringify(fieldMappings.compliance.emissions),
+    );
+
+    return this.emissionsComplianceMap.many(query);
+  }
+}

--- a/src/emissions-compliance/unit-compliance-dim.repository.spec.ts
+++ b/src/emissions-compliance/unit-compliance-dim.repository.spec.ts
@@ -1,0 +1,121 @@
+import { Test } from '@nestjs/testing';
+import { SelectQueryBuilder } from 'typeorm';
+
+import { EmissionsComplianceParamsDTO } from '../dto/emissions-compliance.params.dto';
+import { UnitComplianceDim } from '../entities/unit-compliance-dim.entity';
+import { State } from '../enum/state.enum';
+import { UnitComplianceDimRepository } from './unit-compliance-dim.repository';
+
+const mockQueryBuilder = () => ({
+  andWhere: jest.fn(),
+  getMany: jest.fn(),
+  select: jest.fn(),
+  innerJoin: jest.fn(),
+  orderBy: jest.fn(),
+  addOrderBy: jest.fn(),
+  getCount: jest.fn(),
+  skip: jest.fn(),
+  take: jest.fn(),
+});
+
+const mockRequest = (url: string) => {
+  return {
+    url,
+    res: {
+      setHeader: jest.fn(),
+    },
+  };
+};
+
+let filters: EmissionsComplianceParamsDTO = {
+  year: [2019, 2020],
+  page: undefined,
+  perPage: undefined,
+  orisCode: [0],
+  ownerOperator: [''],
+  state: [State.AK],
+};
+
+describe('-- UnitComplianceDimRepository --', () => {
+  let unitComplianceDimRepository;
+  let queryBuilder;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        UnitComplianceDimRepository,
+        { provide: SelectQueryBuilder, useFactory: mockQueryBuilder },
+      ],
+    }).compile();
+
+    unitComplianceDimRepository = module.get<UnitComplianceDimRepository>(
+      UnitComplianceDimRepository,
+    );
+    queryBuilder = module.get<SelectQueryBuilder<UnitComplianceDim>>(
+      SelectQueryBuilder,
+    );
+
+    unitComplianceDimRepository.createQueryBuilder = jest
+      .fn()
+      .mockReturnValue(queryBuilder);
+    queryBuilder.select.mockReturnValue(queryBuilder);
+    queryBuilder.innerJoin.mockReturnValue(queryBuilder);
+    queryBuilder.andWhere.mockReturnValue(queryBuilder);
+    queryBuilder.orderBy.mockReturnValue(queryBuilder);
+    queryBuilder.addOrderBy.mockReturnValue(queryBuilder);
+    queryBuilder.skip.mockReturnValue(queryBuilder);
+    queryBuilder.getMany.mockReturnValue('mockEmissionsCompliance');
+    queryBuilder.take.mockReturnValue('mockPagination');
+    queryBuilder.getCount.mockReturnValue('mockCount');
+  });
+
+  describe('getEmissionsCompliance', () => {
+    it('calls createQueryBuilder and gets all UnitComplianceDim results from the repository', async () => {
+      const emptyFilters: EmissionsComplianceParamsDTO = new EmissionsComplianceParamsDTO();
+
+      let result = await unitComplianceDimRepository.getEmissionsCompliance(
+        emptyFilters,
+      );
+
+      result = await unitComplianceDimRepository.getEmissionsCompliance(
+        filters,
+      );
+
+      expect(queryBuilder.getMany).toHaveBeenCalled();
+      expect(result).toEqual('mockEmissionsCompliance');
+    });
+
+    it('calls createQueryBuilder and gets page 1 of UnitComplianceDim paginated results from the repository', async () => {
+      let paginatedFilters = filters;
+      paginatedFilters.page = 1;
+      paginatedFilters.perPage = 5;
+      let req: any = mockRequest(
+        `/emissions-compliance?page=${paginatedFilters.page}&perPage=${paginatedFilters.perPage}`,
+      );
+      req.res.setHeader.mockReturnValue();
+      let paginatedResult = await unitComplianceDimRepository.getEmissionsCompliance(
+        paginatedFilters,
+        req,
+      );
+      expect(req.res.setHeader).toHaveBeenCalled();
+      expect(queryBuilder.getMany).toHaveBeenCalled();
+      expect(paginatedResult).toEqual('mockEmissionsCompliance');
+    });
+  });
+  it('calls createQueryBuilder and gets page 2 of UnitComplianceDim paginated results from the repository', async () => {
+    let paginatedFilters = filters;
+    paginatedFilters.page = 2;
+    paginatedFilters.perPage = 5;
+    let req: any = mockRequest(
+      `/emissions-compliance?page=${paginatedFilters.page}&perPage=${paginatedFilters.perPage}`,
+    );
+    req.res.setHeader.mockReturnValue();
+    let paginatedResult = await unitComplianceDimRepository.getEmissionsCompliance(
+      paginatedFilters,
+      req,
+    );
+    expect(req.res.setHeader).toHaveBeenCalled();
+    expect(queryBuilder.getMany).toHaveBeenCalled();
+    expect(paginatedResult).toEqual('mockEmissionsCompliance');
+  });
+});

--- a/src/emissions-compliance/unit-compliance-dim.repository.ts
+++ b/src/emissions-compliance/unit-compliance-dim.repository.ts
@@ -1,0 +1,65 @@
+import { EntityRepository, Repository } from 'typeorm';
+import { Request } from 'express';
+
+import { QueryBuilderHelper } from '../utils/query-builder.helper';
+import { ResponseHeaders } from '../utils/response.headers';
+import { UnitComplianceDim } from '../entities/unit-compliance-dim.entity';
+import { EmissionsComplianceParamsDTO } from '../dto/emissions-compliance.params.dto';
+
+@EntityRepository(UnitComplianceDim)
+export class UnitComplianceDimRepository extends Repository<UnitComplianceDim> {
+  async getEmissionsCompliance(
+    emissionsComplianceParamsDTO: EmissionsComplianceParamsDTO,
+    req: Request,
+  ): Promise<UnitComplianceDim[]> {
+    const { page, perPage } = emissionsComplianceParamsDTO;
+    let query = this.createQueryBuilder('ucd')
+      .select([
+        'ucd.year',
+        'ucd.id',
+        'ucd.complianceApproach',
+        'ucd.avgPlanId',
+        'ucd.emissionsLimitDisplay',
+        'ucd.actualEmissionsRate',
+        'ucd.avgPlanActual',
+        'ucd.inCompliance',
+        'uf.state',
+        'uf.facilityName',
+        'uf.orisCode',
+        'uf.unitId',
+        'uf.programCodeInfo',
+        'odf.ownDisplay',
+        'odf.oprDisplay',
+      ])
+      .innerJoin('ucd.unitFact', 'uf')
+      .innerJoin('ucd.ownerDisplayFact', 'odf');
+
+    query = QueryBuilderHelper.createAccountQuery(
+      query,
+      emissionsComplianceParamsDTO,
+      ['orisCode', 'state'],
+      'ucd',
+      'uf',
+      true,
+    );
+    query = QueryBuilderHelper.createComplianceQuery(
+      query,
+      emissionsComplianceParamsDTO,
+      ['year', 'ownerOperator'],
+      'ucd',
+    );
+
+    query
+      .orderBy('uf.programCodeInfo')
+      .addOrderBy('ucd.year')
+      .addOrderBy('uf.orisCode')
+      .addOrderBy('uf.unitId');
+
+    if (page && perPage) {
+      const totalCount = await query.getCount();
+      ResponseHeaders.setPagination(page, perPage, totalCount, req);
+    }
+
+    return query.getMany();
+  }
+}

--- a/src/entities/owner-display-fact.entity.ts
+++ b/src/entities/owner-display-fact.entity.ts
@@ -1,0 +1,31 @@
+import { BaseEntity, Column, Entity, OneToOne, PrimaryColumn } from 'typeorm';
+import { UnitComplianceDim } from './unit-compliance-dim.entity';
+
+@Entity({ name: 'camddmw.owner_display_fact' })
+export class OwnerDisplayFact extends BaseEntity {
+  @PrimaryColumn({
+    name: 'unit_id',
+  })
+  id: number;
+
+  @PrimaryColumn({
+    name: 'op_year',
+  })
+  year: number;
+
+  @Column({
+    name: 'own_display',
+  })
+  ownDisplay: string;
+
+  @Column({
+    name: 'opr_display',
+  })
+  oprDisplay: string;
+
+  @OneToOne(
+    () => UnitComplianceDim,
+    ucd => ucd.ownerDisplayFact,
+  )
+  unitComplianceDim: UnitComplianceDim;
+}

--- a/src/entities/unit-compliance-dim.entity.ts
+++ b/src/entities/unit-compliance-dim.entity.ts
@@ -1,0 +1,85 @@
+import {
+  BaseEntity,
+  Column,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryColumn,
+} from 'typeorm';
+import { UnitFact } from './unit-fact.entity';
+import { OwnerDisplayFact } from './owner-display-fact.entity';
+
+@Entity({ name: 'camddmw.unit_compliance_dim' })
+export class UnitComplianceDim extends BaseEntity {
+  @PrimaryColumn({
+    name: 'unit_id',
+  })
+  id: number;
+
+  @PrimaryColumn({
+    name: 'op_year',
+  })
+  year: number;
+
+  @Column({
+    name: 'comp_plan_type_cd',
+  })
+  complianceApproach: string;
+
+  @Column({
+    name: 'avg_plan_id',
+  })
+  avgPlanId: number;
+
+  @Column({
+    name: 'in_compliance',
+  })
+  inCompliance: string;
+
+  @Column({
+    name: 'act_emiss_rate',
+  })
+  actualEmissionsRate: number;
+
+  @Column({
+    name: 'avg_plan_act_emiss_rate',
+  })
+  avgPlanActual: number;
+
+  @Column({
+    name: 'emiss_limit_display',
+  })
+  emissionsLimitDisplay: number;
+
+  @OneToOne(
+    () => UnitFact,
+    uf => uf.unitComplianceDim,
+  )
+  @JoinColumn([
+    {
+      name: 'unit_id',
+      referencedColumnName: 'id',
+    },
+    {
+      name: 'op_year',
+      referencedColumnName: 'year',
+    },
+  ])
+  unitFact: UnitFact;
+
+  @OneToOne(
+    () => OwnerDisplayFact,
+    odf => odf.unitComplianceDim,
+  )
+  @JoinColumn([
+    {
+      name: 'unit_id',
+      referencedColumnName: 'id',
+    },
+    {
+      name: 'op_year',
+      referencedColumnName: 'year',
+    },
+  ])
+  ownerDisplayFact: OwnerDisplayFact;
+}

--- a/src/entities/unit-fact.entity.ts
+++ b/src/entities/unit-fact.entity.ts
@@ -1,0 +1,44 @@
+import { BaseEntity, Column, Entity, OneToOne, PrimaryColumn } from 'typeorm';
+import { UnitComplianceDim } from './unit-compliance-dim.entity';
+
+@Entity({ name: 'camddmw.unit_fact' })
+export class UnitFact extends BaseEntity {
+  @PrimaryColumn({
+    name: 'unit_id',
+  })
+  id: number;
+
+  @PrimaryColumn({
+    name: 'op_year',
+  })
+  year: number;
+
+  @Column({
+    name: 'unitid',
+  })
+  unitId: string;
+
+  @Column({
+    name: 'facility_name',
+  })
+  facilityName: string;
+
+  @Column({
+    name: 'orispl_code',
+  })
+  orisCode: number;
+
+  @Column()
+  state: string;
+
+  @Column({
+    name: 'prg_code_info',
+  })
+  programCodeInfo: string;
+
+  @OneToOne(
+    () => UnitComplianceDim,
+    ucd => ucd.unitFact,
+  )
+  unitComplianceDim: UnitComplianceDim;
+}

--- a/src/maps/emissions-compliance.map.ts
+++ b/src/maps/emissions-compliance.map.ts
@@ -10,8 +10,7 @@ export class EmissionsComplianceMap extends BaseMap<
   EmissionsComplianceDTO
 > {
   public async one(entity: UnitComplianceDim): Promise<EmissionsComplianceDTO> {
-    let ownerOperator;
-    let array = [
+    const array = [
       entity.ownerDisplayFact.ownDisplay,
       entity.ownerDisplayFact.oprDisplay,
     ];
@@ -21,7 +20,7 @@ export class EmissionsComplianceMap extends BaseMap<
       .slice(0, -1)
       .split('),');
     const ownOprUniqueList = [...new Set(ownOprList)];
-    ownerOperator = ownOprUniqueList.join('),');
+    const ownerOperator = ownOprUniqueList.join('),');
     return {
       year: entity.year,
       facilityName: entity.unitFact.facilityName,

--- a/src/maps/emissions-compliance.map.ts
+++ b/src/maps/emissions-compliance.map.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@nestjs/common';
+
+import { BaseMap } from './base.map';
+import { UnitComplianceDim } from '../entities/unit-compliance-dim.entity';
+import { EmissionsComplianceDTO } from '../dto/emissions-compliance.dto';
+
+@Injectable()
+export class EmissionsComplianceMap extends BaseMap<
+  UnitComplianceDim,
+  EmissionsComplianceDTO
+> {
+  public async one(entity: UnitComplianceDim): Promise<EmissionsComplianceDTO> {
+    let ownerOperator;
+    let array = [
+      entity.ownerDisplayFact.ownDisplay,
+      entity.ownerDisplayFact.oprDisplay,
+    ];
+    const ownOprList = array
+      .filter(e => e)
+      .join(',')
+      .slice(0, -1)
+      .split('),');
+    const ownOprUniqueList = [...new Set(ownOprList)];
+    ownerOperator = ownOprUniqueList.join('),');
+    return {
+      year: entity.year,
+      facilityName: entity.unitFact.facilityName,
+      facilityId: entity.unitFact.orisCode
+        ? Number(entity.unitFact.orisCode)
+        : entity.unitFact.orisCode,
+      unitId: entity.unitFact.unitId,
+      ownerOperator: ownerOperator.length > 0 ? `${ownerOperator})` : null,
+      state: entity.unitFact.state,
+      complianceApproach: entity.complianceApproach,
+      avgPlanId: entity.avgPlanId ? Number(entity.avgPlanId) : entity.avgPlanId,
+      emissionsLimitDisplay: entity.emissionsLimitDisplay
+        ? Number(entity.emissionsLimitDisplay)
+        : entity.emissionsLimitDisplay,
+      actualEmissionsRate: entity.actualEmissionsRate
+        ? Number(entity.actualEmissionsRate)
+        : entity.actualEmissionsRate,
+      avgPlanActual: entity.avgPlanActual
+        ? Number(entity.avgPlanActual)
+        : entity.avgPlanActual,
+      inCompliance: entity.inCompliance,
+    };
+  }
+}

--- a/src/utils/query-builder.helper.ts
+++ b/src/utils/query-builder.helper.ts
@@ -187,7 +187,7 @@ export class QueryBuilderHelper {
     dto: any,
     param: string[],
     complianceAlias: string,
-    ownerAlias: string = 'odf',
+    ownerAlias = 'odf',
   ) {
     if (param.includes('year') && dto.year) {
       query.andWhere(`${complianceAlias}.year IN (:...years)`, {

--- a/src/utils/query-builder.helper.ts
+++ b/src/utils/query-builder.helper.ts
@@ -187,11 +187,28 @@ export class QueryBuilderHelper {
     dto: any,
     param: string[],
     complianceAlias: string,
+    ownerAlias: string = 'odf',
   ) {
     if (param.includes('year') && dto.year) {
       query.andWhere(`${complianceAlias}.year IN (:...years)`, {
         years: dto.year,
       });
+    }
+
+    if (param.includes('ownerOperator') && dto.ownerOperator) {
+      let string = '(';
+
+      for (let i = 0; i < dto.ownerOperator.length; i++) {
+        const regex = Regex.commaDelimited(dto.ownerOperator[i].toUpperCase());
+
+        if (i === 0) {
+          string += `(UPPER(${ownerAlias}.ownDisplay) ~* ${regex}) `;
+        } else {
+          string += `OR (UPPER(${ownerAlias}.oprDisplay) ~* ${regex}) `;
+        }
+      }
+      string += ')';
+      query.andWhere(string);
     }
 
     if (dto.page && dto.perPage) {


### PR DESCRIPTION
## Pull Request

```
- Added emissions-compliance endpoint by modifying controller and module and adding service
- Added unit-compliance-dim repo and modified query builder to account for owner/operator
- Added emissions-compliance DTO, paramsDTO, and map
- Modified compliance fields and added field mappings for emissions-compliance
- Added unit-fact, owner-display-fact, and unit-compliance-dim entities
- Unit tests

```
