### PR TITLE
Feature/1273 adding caspar ozone group 3 data to account api

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@nestjs/platform-express": "^8.1.1",
     "@nestjs/swagger": "^5.1.2",
     "@nestjs/typeorm": "^8.0.2",
-    "@us-epa-camd/easey-common": "^1.8.2",
+    "@us-epa-camd/easey-common": "^1.9.0",
     "class-transformer": "^0.4.0",
     "class-validator": "^0.13.1",
     "dotenv": "^10.0.0",

--- a/src/dto/allowance-holdings.params.dto.ts
+++ b/src/dto/allowance-holdings.params.dto.ts
@@ -9,7 +9,7 @@ import { IsYearFormat } from '@us-epa-camd/easey-common/pipes';
 
 import { IsYearGreater } from '../pipes/is-year-greater.pipe';
 import { IsAllowanceProgram } from '../pipes/is-allowance-program.pipe';
-import { ActiveAllowanceProgram } from '../enum/active-allowance-program.enum';
+import { ActiveAllowanceProgram } from '@us-epa-camd/easey-common/enums';
 import { AllowanceParamsDTO } from './allowance.params.dto';
 
 export class AllowanceHoldingsParamsDTO extends AllowanceParamsDTO {

--- a/src/enum/active-allowance-program.enum.ts
+++ b/src/enum/active-allowance-program.enum.ts
@@ -1,9 +1,0 @@
-export enum ActiveAllowanceProgram {
-  ARP = 'ARP',
-  CSNOX = 'CSNOX',
-  CSOSG1 = 'CSOSG1',
-  CSOSG2 = 'CSOSG2',
-  CSSO2G1 = 'CSSO2G1',
-  CSSO2G2 = 'CSSO2G2',
-  TXSO2 = 'TXSO2',
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1053,10 +1053,10 @@
     "@typescript-eslint/types" "5.1.0"
     eslint-visitor-keys "^3.0.0"
 
-"@us-epa-camd/easey-common@^1.8.2":
-  version "1.8.2"
-  resolved "https://npm.pkg.github.com/download/@us-epa-camd/easey-common/1.8.2/cf3ff2c275460e46a89bfcb4df172e24280f252dd81dee81eb0063a61413944a#e80ca474a27105feeb3bbdaebb1274601261748a"
-  integrity sha512-3z1IdZSYqnWUsPGCGZ0r1vOsNYHZTnWf8sMYU8AnwgvxWKLc+4bWe5R8Et/aCpnkPVxUGCapCWbVfRaqv0Vjtw==
+"@us-epa-camd/easey-common@^1.9.0":
+  version "1.9.0"
+  resolved "https://npm.pkg.github.com/download/@us-epa-camd/easey-common/1.9.0/7b17d0c4df901e12813adacdf71adb472dfc44b3aa773c7adec1bb8fe23cf731#43e5acd2b08266f9302e36835555288e7dd23460"
+  integrity sha512-eRCXgvrSAKhgEPv6F4FG4vw8rq0vI4IcLJF0RA0T9lP1O4Zhe567B0wKoM6IX4hhwCULl8ouEZ/QAcKWFzXvLQ==
   dependencies:
     "@nestjs/axios" "0.0.3"
     "@nestjs/common" "^8.1.1"


### PR DESCRIPTION
## Pull Request

```
- updated easey-common version
- deleted active allowance enum no longer needed 
- imported active allowance program enum for allowance holdings from easey-common

```
