### PR TITLE
class-validator-patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "up": "yarn && yarn start:dev"
   },
   "resolutions": {
-    "ansi-regex": "^5.0.1"
+    "ansi-regex": "^5.0.1",
+    "class-transformer": "0.4.0",
+    "class-validator": "0.13.1"
   },
   "dependencies": {
     "@nestjs/axios": "0.0.3",
@@ -39,7 +41,7 @@
     "@nestjs/typeorm": "8.0.3",
     "@us-epa-camd/easey-common": "11.1.0",
     "class-transformer": "0.4.0",
-    "class-validator": "^0.13.1",
+    "class-validator": "0.13.1",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
     "moment": "^2.29.4",


### PR DESCRIPTION
rolling class-validator back to 0.13.1 since 0.14.0 breaks things