### PR TITLE
Fix/#4888 remove owner operator update swagger

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@nestjs/platform-express": "^8.1.1",
     "@nestjs/swagger": "^5.1.2",
     "@nestjs/typeorm": "8.0.3",
-    "@us-epa-camd/easey-common": "11.4.1",
+    "@us-epa-camd/easey-common": "11.4.3",
     "class-transformer": "0.4.0",
     "class-validator": "^0.13.1",
     "dotenv": "^10.0.0",

--- a/src/maps/allowance-compliance.map.ts
+++ b/src/maps/allowance-compliance.map.ts
@@ -31,7 +31,7 @@ export class AllowanceComplianceMap extends BaseMap<
       totalAllowancesDeducted: entity.totalAllowancesDeducted,
       carriedOver: entity.carriedOver,
       excessEmissions: entity.excessEmissions,
-      ownerOperator: entity.accountFact.ownerOperator.replace(",", "|"),
+      ownerOperator: entity.accountFact.ownerOperator,
       stateCode: entity.accountFact.stateCode,
     };
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1176,10 +1176,11 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
-"@us-epa-camd/easey-common@11.4.1":
-  version "11.4.1"
-  resolved "https://npm.pkg.github.com/download/@US-EPA-CAMD/easey-common/11.4.1/6cd33fae6c97cf90af84eb164dfc6c6ef9fe3d11#6cd33fae6c97cf90af84eb164dfc6c6ef9fe3d11"
-  integrity sha512-Gj1QRMeouxlR7tG/4Az9c7XQlQqob6Atxk8UMa8c8lflKWlkGCj4dbFuYTLVtdlxYpOU0al81yzvHWe/CqwkIg==
+
+"@us-epa-camd/easey-common@11.4.3":
+  version "11.4.3"
+  resolved "https://npm.pkg.github.com/download/@US-EPA-CAMD/easey-common/11.4.3/bb5470d178e5f1a2734c44705786a06a19bf5184#bb5470d178e5f1a2734c44705786a06a19bf5184"
+  integrity sha512-Ur+6nYPlLWgewygUq17cxXwwq/hPIhkPjyxB6qCL5eUXW0EOHxeu4YBVK7bRVDz9oTgm7Dhw1KZq/sGjpCjeyA==
   dependencies:
     "@nestjs/axios" "0.0.3"
     "@nestjs/common" "^8.1.1"


### PR DESCRIPTION
## Ticket
[Change delimiter in OwnerOperator](https://github.com/US-EPA-CAMD/easey-ui/issues/4888)

## Changes

1. Remove extra pipe from allowance compliance
2. Update common package for `ownerOperator` swagger example 

## Step to test

1. Call allowance-compliance Api with  `facilityId`: 2828, `programCodeInfo`: APR,  `page`: 1 and `perPage`: 100
2. Check swagger ownerOperator example value