### PR TITLE
fix(6185): removed lingering 'EntityRepository' decorators

### DIFF
--- a/src/allowance-compliance/account-compliance-dim.repository.spec.ts
+++ b/src/allowance-compliance/account-compliance-dim.repository.spec.ts
@@ -1,11 +1,11 @@
 import { Test } from '@nestjs/testing';
-import { SelectQueryBuilder } from 'typeorm';
+import { EntityManager, SelectQueryBuilder } from 'typeorm';
 
-import { State, AllowanceProgram } from '@us-epa-camd/easey-common/enums';
+import { AllowanceProgram, State } from '@us-epa-camd/easey-common/enums';
 
+import { ResponseHeaders } from '@us-epa-camd/easey-common/utilities';
 import { PaginatedAllowanceComplianceParamsDTO } from '../dto/allowance-compliance.params.dto';
 import { AccountComplianceDimRepository } from './account-compliance-dim.repository';
-import { ResponseHeaders } from '@us-epa-camd/easey-common/utilities';
 
 const mockQueryBuilder = () => ({
   andWhere: jest.fn(),
@@ -55,6 +55,7 @@ describe('-- AccountComplianceDimRepository --', () => {
     const module = await Test.createTestingModule({
       providers: [
         AccountComplianceDimRepository,
+        EntityManager,
         { provide: SelectQueryBuilder, useFactory: mockQueryBuilder },
       ],
     }).compile();

--- a/src/allowance-compliance/account-compliance-dim.repository.ts
+++ b/src/allowance-compliance/account-compliance-dim.repository.ts
@@ -1,22 +1,26 @@
-import { AccountOwnerDim } from './../entities/account-owner-dim.entity';
-import { EntityRepository, Repository, SelectQueryBuilder } from 'typeorm';
-import { Request } from 'express';
-
+import { Injectable } from '@nestjs/common';
 import { ResponseHeaders } from '@us-epa-camd/easey-common/utilities';
+import { Request } from 'express';
+import { EntityManager, Repository, SelectQueryBuilder } from 'typeorm';
 
-import { QueryBuilderHelper } from '../utils/query-builder.helper';
-import { AccountComplianceDim } from '../entities/account-compliance-dim.entity';
 import {
   AllowanceComplianceParamsDTO,
   PaginatedAllowanceComplianceParamsDTO,
 } from '../dto/allowance-compliance.params.dto';
+import { AccountComplianceDim } from '../entities/account-compliance-dim.entity';
 import { AccountFact } from '../entities/account-fact.entity';
 import { includesOtcNbp } from '../utils/includes-otc-nbp.const';
+import { QueryBuilderHelper } from '../utils/query-builder.helper';
+import { AccountOwnerDim } from './../entities/account-owner-dim.entity';
 
-@EntityRepository(AccountComplianceDim)
+@Injectable()
 export class AccountComplianceDimRepository extends Repository<
   AccountComplianceDim
 > {
+  constructor(entityManager: EntityManager) {
+    super(AccountComplianceDim, entityManager);
+  }
+
   async getAllowanceCompliance(
     params: PaginatedAllowanceComplianceParamsDTO,
     req: Request,

--- a/src/allowance-compliance/allowance-compliance.controller.spec.ts
+++ b/src/allowance-compliance/allowance-compliance.controller.spec.ts
@@ -2,6 +2,7 @@ import { Test } from '@nestjs/testing';
 import { AllowanceProgram } from '@us-epa-camd/easey-common/enums';
 import { State } from '@us-epa-camd/easey-common/enums';
 import { LoggerModule } from '@us-epa-camd/easey-common/logger';
+import { EntityManager } from 'typeorm';
 
 import { AllowanceComplianceMap } from '../maps/allowance-compliance.map';
 import { AccountComplianceDimRepository } from './account-compliance-dim.repository';
@@ -37,6 +38,7 @@ describe('-- Allowance Compliance Controller --', () => {
         AllowanceComplianceService,
         AllowanceComplianceMap,
         AccountComplianceDimRepository,
+        EntityManager,
         OwnerYearDimRepository,
         OwnerOperatorsMap,
         ApplicableAllowanceComplianceAttributesMap,

--- a/src/allowance-compliance/allowance-compliance.service.ts
+++ b/src/allowance-compliance/allowance-compliance.service.ts
@@ -1,9 +1,4 @@
-import {
-  HttpStatus,
-  Injectable,
-  InternalServerErrorException,
-} from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { HttpStatus, Injectable } from '@nestjs/common';
 import { Request } from 'express';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 
@@ -28,10 +23,8 @@ import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
 @Injectable()
 export class AllowanceComplianceService {
   constructor(
-    @InjectRepository(AccountComplianceDimRepository)
     private readonly accountComplianceDimRepository: AccountComplianceDimRepository,
     private readonly allowanceComplianceMap: AllowanceComplianceMap,
-    @InjectRepository(OwnerYearDimRepository)
     private readonly ownerYearDimRepository: OwnerYearDimRepository,
     private readonly ownerOperatorsMap: OwnerOperatorsMap,
     private readonly applicableAllowanceComplianceAttributesMap: ApplicableAllowanceComplianceAttributesMap,

--- a/src/allowance-compliance/owner-year-dim.repository.spec.ts
+++ b/src/allowance-compliance/owner-year-dim.repository.spec.ts
@@ -1,9 +1,9 @@
 import { Test } from '@nestjs/testing';
-import { SelectQueryBuilder } from 'typeorm';
+import { EntityManager, SelectQueryBuilder } from 'typeorm';
 
 import { OwnerOperatorsDTO } from '../dto/owner-operators.dto';
-import { OwnerYearDimRepository } from './owner-year-dim.repository';
 import { OwnerYearDim } from '../entities/owner-year-dim.entity';
+import { OwnerYearDimRepository } from './owner-year-dim.repository';
 
 const mockQueryBuilder = () => ({
   select: jest.fn(),
@@ -21,6 +21,7 @@ describe('OwnerYearDimRepository', () => {
   beforeEach(async () => {
     const module = await Test.createTestingModule({
       providers: [
+        EntityManager,
         OwnerYearDimRepository,
         { provide: SelectQueryBuilder, useFactory: mockQueryBuilder },
       ],

--- a/src/allowance-compliance/owner-year-dim.repository.ts
+++ b/src/allowance-compliance/owner-year-dim.repository.ts
@@ -1,9 +1,14 @@
-import { Repository, EntityRepository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { EntityManager, Repository } from 'typeorm';
 
 import { OwnerYearDim } from '../entities/owner-year-dim.entity';
 
-@EntityRepository(OwnerYearDim)
+@Injectable()
 export class OwnerYearDimRepository extends Repository<OwnerYearDim> {
+  constructor(entityManager: EntityManager) {
+    super(OwnerYearDim, entityManager);
+  }
+
   async getAllOwnerOperators(): Promise<OwnerYearDim[]> {
     const query = this.createQueryBuilder('oyd')
       .select(['oyd.ownerOperator', 'oyd.ownType'])


### PR DESCRIPTION
## Main Changes

- While working on [updating CAMPD](https://github.com/US-EPA-CAMD/easey-ui/issues/6290), I came across a couple remaining instances of the `EntityRepository` decorator in this repository. These have been removed and updated to the new method of creating custom repositories.